### PR TITLE
Pass key prop as an argument to highlight()

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -51,7 +51,7 @@ compile = (node, parentKey='_start', tableAlign = null) ->
     when 'horizontalRule' then $ 'hr', {key}
     when 'image'          then $ 'img', {key, src: node.src, title: node.title, alt: node.alt}
     when 'inlineCode'     then $ 'code', {key, className:'inlineCode'}, node.value
-    when 'code'           then highlight node.value, node.lang
+    when 'code'           then highlight key, node.value, node.lang
 
     # Has children
     when 'root'       then $ 'div', {key}, toChildren(node, key)
@@ -118,7 +118,7 @@ htmlWrapperComponent = null
 module.exports = (raw, options = {}) ->
   htmlWrapperComponent = options.htmlWrapperComponent ? defaultHTMLWrapper
   sanitize = options.sanitize ? true
-  highlight = options.highlight ? (code, lang) ->
+  highlight = options.highlight ? (key, code, lang) ->
     $ 'pre', {key, className: 'code'}, [
       $ 'code', {key: key+'-_inner-code'}, code
     ]


### PR DESCRIPTION
The default highlight option raises `ReferenceError: key is not defined`.

``````
var md2react = require('md2react');
var rendered = md2react("```\na\n```\n"); // ReferenceError: key is not defined
``````

This pr is a quick fix for it.
