### PR TITLE
Implement footnotes

### DIFF
--- a/playground/index.coffee
+++ b/playground/index.coffee
@@ -57,6 +57,7 @@ Editor = React.createClass
         breaks: true
         tables: true
         commonmark: true
+        footnotes: true
         # highlight: (code, lang, key) -> # custom highlighter
         #   "#{lang}: #{code}"
       @setState content: content


### PR DESCRIPTION
@mizchi review plz

Closes #8 
## 処理の流れ
### 前提

以下の Markdown を入力すると考える：

```
[^foo] text [^bar] text [^qux] text

[^bar]: BAR
[^qux]: QUX
[^foo]: FOO
```

脚注参照（`[^foo]`, `[^bar]`）は mdast の `footnoteReference` ノードになる。

脚注定義（`[^foo]: FOO`）は `footnoteDefinition` ノードになる（ただし mdast にバグがあり、脚注定義が条件によって後置リンク定義と解釈されることがある。この場合 `definition` ノードになる）

これを元に、下のコメントに貼ったような HTML を出力する。
### 1. 脚注番号を振る

脚注参照ノードに1から始まる脚注番号を振る。出現順に `aFootnoteReferenceNode.footnoteNumber = n` をセットしていく。同じ脚注IDが2回以上現れたら最初に振った番号を使い回す。

例：以下の Markdown があるとき、脚注番号は順に 1, 2, 1, 3 となる。

```
[^foo] hoge [^bar] fuga [^foo] piyo [^qux]
```
### 2. 脚注定義に脚注番号をセットする

手順1で振った脚注番号を元に、脚注定義ノードに脚注番号をセットする。 

``` coffee
# 脚注IDから脚注番号へのマッピングを手順1で作っておく
mapping = {foo: 1, bar: 2, qux: 3}

# マッピングを使って各脚注定義ノードに脚注番号をセットする
aFootnoteReferenceNode.nodeNumber = mapping[footnodeId]
```
### 3. 脚注定義ノードを AST の最後にまとめる

脚注定義は文章中のどこに書いてもいいが、レンダリング時には文章の最後に配置したい。いったん脚注定義ノードを取り除き、ひとまとめにして脚注定義集合ノードとする。それをルートノードの children の末尾に追加する。

脚注定義集合ノードの要素は脚注番号の昇順にソートする。つまり、脚注参照の出現順に脚注定義を並べる。

```
# 脚注参照 `[^foo]` が先に出現するので…
[^foo] text [^bar] text

# 脚注定義を逆順に並べても [^foo]: FOO が先にレンダリングされる
[^bar]: BAR
[^foo]: FOO
```

また、対応する脚注参照が存在しない脚注定義ノードは捨てる。
### 4. レンダリング

それっぽくなるように頑張る。
