### PR TITLE
Support computed html node

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -155,6 +155,14 @@ compile = (node, defs, parentKey='_start', tableAlign = null) ->
 
     # Raw html
     when 'html'
+      if node.subtype is 'computed'
+        k = key+'_'+node.tagName
+        props = node.attrs.slice() # make a sharrow copy
+        props.key = k
+        if node.children?
+          $ node.tagName, props, toChildren(node, defs, k)
+        else
+          $ node.tagName, props
       if node.subtype is 'folded'
         k = key+'_'+node.tagName
         props = getPropsFromHTMLNode(node, ATTR_WHITELIST) ? {}


### PR DESCRIPTION
@mizchi こういうの入れます

html ノードに `computed` subtype を追加する。`computed` ノードは `preprocessAST` オプションで与えられた関数によって作られることを想定している。

`preprocessAST` でノードを操作して任意の attr を持つ html ノードを追加したいとき、これまでは attr を埋め込んだタグ文字列を組み立てるしかなかった。 `computed` ノードは `attrs` プロパティに任意の attr を指定できる。
